### PR TITLE
Tweak "show hints" logic

### DIFF
--- a/src/components/AnswerForm.vue
+++ b/src/components/AnswerForm.vue
@@ -26,8 +26,14 @@
     </div>
     <div class="c-answer-form__input-group c-answer-form__hint">
       <label class="c-answer-form__hint-label">
-        <input type="checkbox" :value="showHint" @change="onToggleHint" class="c-answer-form__hint-checkbox" /> Show
-        hints?
+        <input
+          type="checkbox"
+          :checked="showHint"
+          @change="onToggleHint"
+          class="c-answer-form__hint-checkbox"
+          :disabled="showHint"
+        />
+        Show hints?
       </label>
       <ColorRect size="s" :color="answerCssColor" v-if="showHint"></ColorRect>
     </div>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -74,6 +74,9 @@ export default createComponent({
         answer: answerRGB,
         usedHint: showHint.value,
       });
+
+      showHint.value = false;
+
       nextRGB();
     };
 


### PR DESCRIPTION
Now "Show hints?" can't be toggled off once toggled on and is reset every round.